### PR TITLE
fix: download binaries to a subfolder

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -64,6 +64,7 @@ pub async fn auto_download() -> Result<()> {
 
   let download_url = ffmpeg_download_url()?;
   let destination = sidecar_dir()?;
+  tokio::fs::create_dir_all(&destination).await?;
   let archive_path = download_ffmpeg_package(download_url, &destination).await?;
   unpack_ffmpeg(&archive_path, &destination).await?;
 

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -2,8 +2,8 @@
 
 use anyhow::Context;
 use std::{
-    env::current_exe,
-    path::{Path, PathBuf}
+  env::current_exe,
+  path::{Path, PathBuf},
 };
 
 /// Returns the default path of the FFmpeg executable, to be used as the
@@ -13,14 +13,14 @@ use std::{
 /// informative error message should be printed (not when this function is
 /// called, but when the command is actually run).
 pub fn ffmpeg_path() -> PathBuf {
-    let default = Path::new("ffmpeg").to_path_buf();
-    match sidecar_path() {
-        Ok(sidecar_path) => match sidecar_path.exists() {
-            true => sidecar_path,
-            false => default,
-        },
-        Err(_) => default,
-    }
+  let default = Path::new("ffmpeg").to_path_buf();
+  match sidecar_path() {
+    Ok(sidecar_path) => match sidecar_path.exists() {
+      true => sidecar_path,
+      false => default,
+    },
+    Err(_) => default,
+  }
 }
 
 /// The (expected) path to an FFmpeg binary adjacent to the Rust binary.
@@ -28,22 +28,23 @@ pub fn ffmpeg_path() -> PathBuf {
 /// The extension between platforms, with Windows using `.exe`, while Mac and
 /// Linux have no extension.
 pub fn sidecar_path() -> anyhow::Result<PathBuf> {
-    let mut path = current_exe()?
-        .parent()
-        .context("Can't get parent of current_exe")?
-        .join("ffmpeg");
-    if cfg!(windows) {
-        path.set_extension("exe");
-    }
-    Ok(path)
+  let mut path = current_exe()?
+    .parent()
+    .context("Can't get parent of current_exe")?
+    .join("ffmpeg_dir")
+    .join("ffmpeg");
+  if cfg!(windows) {
+    path.set_extension("exe");
+  }
+  Ok(path)
 }
 
 /// By default, downloads all temporary files to the same directory as the Rust executable.
 pub fn sidecar_dir() -> anyhow::Result<PathBuf> {
-    Ok(
-        sidecar_path()?
-            .parent()
-            .context("invalid sidecar path")?
-            .to_path_buf(),
-    )
+  Ok(
+    sidecar_path()?
+      .parent()
+      .context("invalid sidecar path")?
+      .to_path_buf(),
+  )
 }


### PR DESCRIPTION
download binaries to a subfolder to avoid executable name colisions