### PR TITLE
feat: Add --examples flag to test commands

### DIFF
--- a/.github/workflows/darwin.yml
+++ b/.github/workflows/darwin.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Check without default features
         run: cargo check --no-default-features
       - name: Run tests
-        run: cargo test --all-targets --all-features --verbose -- --skip lib.rs
+        run: cargo test --all-targets --all-features --examples --verbose

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Check without default features
         run: cargo check --no-default-features
       - name: Run tests
-        run: cargo test --all-targets --all-features --verbose
+        run: cargo test --all-targets --all-features --examples --verbose

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Check without default features
         run: cargo check --no-default-features
       - name: Run tests
-        run: cargo test --all-targets --all-features --verbose
+        run: cargo test --all-targets --all-features --examples --verbose


### PR DESCRIPTION
Adds the --examples flag to the test commands in the GitHub Actions
workflows for Darwin, Ubuntu, and Windows. This ensures that the
examples are also tested as part of the CI process.