### PR TITLE
Fix link to `ffmpeg-sidecar`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@
 [//]: # ([Docs.rs]&#40;https://docs.rs/ffmpeg-sidecar&#41;)
 
 > Wrap a standalone ffmpeg binary in an intuitive Stream interface.
-> This project is mostly a copy of the [ffmpeg-sidecar](https://github.com/nathanbabcock/ffmmpeg-sidecar) project adapted to async. 
+> This project is mostly a copy of the [ffmpeg-sidecar](https://github.com/nathanbabcock/ffmpeg-sidecar) project adapted to async.
 > It contains every future of the said crate apart from raw video frame handling.


### PR DESCRIPTION
The link had an extra `m` in the URL.